### PR TITLE
Pipe fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ VOLUME /mnt/log
 VOLUME /mnt/data
 
 # Run the watcher
-CMD ["/bin/sh", "-c", "./ecs-conex.sh 2>&1 | FASTLOG_PREFIX='[${timestamp}] [ecs-conex] '[${MessageId}] fastlog info >> /mnt/log/application.log"]
+CMD ["/bin/sh", "-c", "./ecs-conex.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ VOLUME /mnt/log
 VOLUME /mnt/data
 
 # Run the watcher
-CMD ["/bin/sh", "-c", "./ecs-conex.sh"]
+CMD ["/bin/sh", "-c", "./ecs-conex.sh  >> /mnt/log/application.log"]

--- a/ecs-conex.sh
+++ b/ecs-conex.sh
@@ -95,4 +95,4 @@ function main() {
 }
 
 trap "cleanup" EXIT
-main 2>&1 | FASTLOG_PREFIX='[${timestamp}] [ecs-conex] '[${MessageId}] fastlog info >> /mnt/log/application.log
+main 2>&1 | FASTLOG_PREFIX='[${timestamp}] [ecs-conex] '[${MessageId}] fastlog info

--- a/ecs-conex.sh
+++ b/ecs-conex.sh
@@ -6,9 +6,6 @@ set -o pipefail
 regions=(us-east-1 us-west-2 eu-west-1)
 tmpdir="$(mktemp -d /mnt/data/XXXXXX)"
 
-trap "cleanup" EXIT
-main | FASTLOG_PREFIX='[${timestamp}] [ecs-conex] '[${MessageId}] fastlog info >> /mnt/log/application.log
-
 function before_image() {
   local region=$1
   echo ${AccountId}.dkr.ecr.${region}.amazonaws.com/${repo}:${before}
@@ -96,3 +93,6 @@ function main() {
 
   echo "completed successfully"
 }
+
+trap "cleanup" EXIT
+main 2>&1 | FASTLOG_PREFIX='[${timestamp}] [ecs-conex] '[${MessageId}] fastlog info >> /mnt/log/application.log

--- a/ecs-conex.sh
+++ b/ecs-conex.sh
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 regions=(us-east-1 us-west-2 eu-west-1)
-tmpdir="/mnt/data/$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)"
+tmpdir="$(mktemp -d /mnt/data/XXXXXX)"
 
 trap "cleanup" EXIT
 main | FASTLOG_PREFIX='[${timestamp}] [ecs-conex] '[${MessageId}] fastlog info >> /mnt/log/application.log


### PR DESCRIPTION
Old mechanism for piping logs through https://github.com/willwhite/fastlog resulted in a container that **always** exited `0`. This mean that to watchbot, every run was successful and nothing ever needed to be retried.
