### PR TITLE
docker@1.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN mkdir -p /usr/local/src/ecs-conex
 WORKDIR /usr/local/src/ecs-conex
 
 # Install docker binary matching EC2 version
-RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1.tgz > docker-1.9.1.tgz
-RUN tar -xzf docker-1.9.1.tgz && cp usr/local/bin/docker /usr/local/bin/docker && chmod 755 /usr/local/bin/docker
+RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.11.1.tgz > docker-1.11.1.tgz
+RUN tar -xzf docker-1.11.1.tgz && cp docker/docker /usr/local/bin/docker && chmod 755 /usr/local/bin/docker
 
 # Copy files into the container
 COPY ./ecs-conex.sh ./ecs-conex.sh


### PR DESCRIPTION
Corresponds to an update of the ECS-optimized AMIs https://aws.amazon.com/about-aws/whats-new/2016/05/amazon-ec2-container-service-supports-docker-1-11/