### PR TITLE
Use deleted flag on push event to ignore branch deletes

### DIFF
--- a/cloudformation/ecs-conex.template.json
+++ b/cloudformation/ecs-conex.template.json
@@ -813,6 +813,7 @@
                                 "    ref: event.body.ref,",
                                 "    after: event.body.after,",
                                 "    before: event.body.before,",
+                                "    deleted: event.body.deleted,",
                                 "    repository: {",
                                 "      name: event.body.repository.name,",
                                 "      owner: { name: event.body.repository.owner.name }",

--- a/ecs-conex.sh
+++ b/ecs-conex.sh
@@ -54,7 +54,7 @@ function parse_message() {
   repo=$(node -e "console.log(${Message}.repository.name);")
   owner=$(node -e "console.log(${Message}.repository.owner.name);")
   user=$(node -e "console.log(${Message}.pusher.name);")
-  deleted=$(node -e "console.log(${Message}).deleted")
+  deleted=$(node -e "console.log(${Message}.deleted);")
   status_url="https://api.github.com/repos/${owner}/${repo}/statuses/${after}?access_token=${GithubAccessToken}"
 }
 

--- a/ecs-conex.sh
+++ b/ecs-conex.sh
@@ -54,6 +54,7 @@ function parse_message() {
   repo=$(node -e "console.log(${Message}.repository.name);")
   owner=$(node -e "console.log(${Message}.repository.owner.name);")
   user=$(node -e "console.log(${Message}.pusher.name);")
+  deleted=$(node -e "console.log(${Message}).deleted")
   status_url="https://api.github.com/repos/${owner}/${repo}/statuses/${after}?access_token=${GithubAccessToken}"
 }
 
@@ -86,8 +87,9 @@ function main() {
   parse_message
 
   echo "processing commit ${after} by ${user} to ${ref} of ${owner}/${repo}"
-
   github_status "pending" "ecs-conex is building an image"
+  [ "${deleted}" == "true" ] && exit 0
+
   git clone https://${GithubAccessToken}@github.com/${owner}/${repo} ${tmpdir}
   cd ${tmpdir} && git checkout -q $after || exit 3
 


### PR DESCRIPTION
Fixes #11 which was misdiagnosed -- the failure message arrived when an just-merged branch is deleted.