### PR TITLE
Provide aws credentials as build-args

### DIFF
--- a/ecs-conex.sh
+++ b/ecs-conex.sh
@@ -68,6 +68,19 @@ function credentials() {
   accessKeyId=$(node -e "console.log(${creds}.AccessKeyId)")
   secretAccessKey=$(node -e "console.log(${creds}.SecretAccessKey)")
   sessionToken=$(node -e "console.log(${creds}.SessionToken)")
+
+  args=""
+  if grep -O "ARG AWS_ACCESS_KEY_ID" ./Dockerfile > /dev/null 2>&1; then
+    [ -n "${accessKeyId}" ] && args="--build-arg AWS_ACCESS_KEY_ID=${accessKeyId} "
+  fi
+
+  if grep -O "ARG AWS_SECRET_ACCESS_KEY" ./Dockerfile > /dev/null 2>&1; then
+    [ -n "${secretAccessKey}" ] && args="--build-arg AWS_ACCESS_KEY_ID=${secretAccessKey} "
+  fi
+
+  if grep -O "ARG AWS_SESSION_TOKEN" ./Dockerfile > /dev/null 2>&1; then
+    [ -n "${sessionToken}" ] && args="--build-arg AWS_ACCESS_KEY_ID=${sessionToken}"
+  fi
 }
 
 function cleanup() {
@@ -117,19 +130,6 @@ function main() {
 
   echo "gather local credentials and setup --build-arg"
   credentials
-
-  args=""
-  if grep -O "ARG AWS_ACCESS_KEY_ID" ./Dockerfile > /dev/null 2>&1; then
-    [ -n "${accessKeyId}" ] && args="--build-arg AWS_ACCESS_KEY_ID=${accessKeyId} "
-  fi
-
-  if grep -O "ARG AWS_SECRET_ACCESS_KEY" ./Dockerfile > /dev/null 2>&1; then
-    [ -n "${secretAccessKey}" ] && args="--build-arg AWS_ACCESS_KEY_ID=${secretAccessKey} "
-  fi
-
-  if grep -O "ARG AWS_SESSION_TOKEN" ./Dockerfile > /dev/null 2>&1; then
-    [ -n "${sessionToken}" ] && args="--build-arg AWS_ACCESS_KEY_ID=${sessionToken}"
-  fi
 
   echo "building new image"
   docker build --quiet ${args} --tag ${repo} ${tmpdir}

--- a/ecs-conex.sh
+++ b/ecs-conex.sh
@@ -58,6 +58,18 @@ function parse_message() {
   status_url="https://api.github.com/repos/${owner}/${repo}/statuses/${after}?access_token=${GithubAccessToken}"
 }
 
+function credentials() {
+  role=$(curl http://169.254.169.254/latest/meta-data/iam/security-credentials/) || :
+  if [ -z "${role}" ]; then
+    return
+  fi
+
+  creds=$(curl http://169.254.169.254/latest/meta-data/iam/security-credentials/${role})
+  accessKeyId=$(node -e "console.log(${creds}.AccessKeyId)")
+  secretAccessKey=$(node -e "console.log(${creds}.SecretAccessKey)")
+  sessionToken=$(node -e "console.log(${creds}.SessionToken)")
+}
+
 function cleanup() {
   exit_code=$?
 
@@ -103,8 +115,24 @@ function main() {
   login ${StackRegion}
   docker pull "$(before_image ${StackRegion})" 2> /dev/null || :
 
+  echo "gather local credentials and setup --build-arg"
+  credentials
+
+  args=""
+  if grep -O "ARG AWS_ACCESS_KEY_ID" ./Dockerfile > /dev/null 2>&1; then
+    [ -n "${accessKeyId}" ] && args="--build-arg AWS_ACCESS_KEY_ID=${accessKeyId} "
+  fi
+
+  if grep -O "ARG AWS_SECRET_ACCESS_KEY" ./Dockerfile > /dev/null 2>&1; then
+    [ -n "${secretAccessKey}" ] && args="--build-arg AWS_ACCESS_KEY_ID=${secretAccessKey} "
+  fi
+
+  if grep -O "ARG AWS_SESSION_TOKEN" ./Dockerfile > /dev/null 2>&1; then
+    [ -n "${sessionToken}" ] && args="--build-arg AWS_ACCESS_KEY_ID=${sessionToken}"
+  fi
+
   echo "building new image"
-  docker build --quiet --tag ${repo} ${tmpdir}
+  docker build --quiet ${args} --tag ${repo} ${tmpdir}
 
   for region in "${regions[@]}"; do
     ensure_repo ${region}

--- a/ecs-conex.sh
+++ b/ecs-conex.sh
@@ -59,12 +59,12 @@ function parse_message() {
 }
 
 function credentials() {
-  role=$(curl http://169.254.169.254/latest/meta-data/iam/security-credentials/) || :
+  role=$(curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/) || :
   if [ -z "${role}" ]; then
     return
   fi
 
-  creds=$(curl http://169.254.169.254/latest/meta-data/iam/security-credentials/${role})
+  creds=$(curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/${role})
   accessKeyId=$(node -e "console.log(${creds}.AccessKeyId)")
   secretAccessKey=$(node -e "console.log(${creds}.SecretAccessKey)")
   sessionToken=$(node -e "console.log(${creds}.SessionToken)")


### PR DESCRIPTION
In situations where a `docker build` needs to fetch private resources (say, from S3), the build command needs to be supplied with `--build-arg`s defining credentials to access those resources.

This PR allows you to write a Dockerfile that relies on [ARG instructions](https://docs.docker.com/engine/reference/builder/#arg) for `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`.

ecs-conex will be running on an EC2. At build-time, it will 
- check the EC2 metadata service and acquire credentials for any available IAM role
- check the Dockerfile for ARG instructions
- if there are credentials to provide, and ARG instructions to use the credentials, then ecs-conex will provide those credentials as `--build-arg`s to `docker build`

cc @jacquestardie 