### PR TITLE
Adds NPMToken stack param

### DIFF
--- a/cloudformation/ecs-conex.template.json
+++ b/cloudformation/ecs-conex.template.json
@@ -57,6 +57,10 @@
             "Description": "The number of MB of memory to reserve for each task",
             "Type": "Number",
             "Default": 512
+        },
+        "NPMToken": {
+            "Type": "String",
+            "Description": "npm access token used to install private packages"
         }
     },
     "Resources": {
@@ -503,6 +507,12 @@
                                 "Name": "GithubAccessToken",
                                 "Value": {
                                     "Ref": "GithubAccessToken"
+                                }
+                            },
+                            {
+                                "Name": "NPMToken",
+                                "Value": {
+                                    "Ref": "NPMToken"
                                 }
                             }
                         ],

--- a/ecs-conex.sh
+++ b/ecs-conex.sh
@@ -107,6 +107,10 @@ function main() {
   AccountId=${AccountId}
   GithubAccessToken=${GithubAccessToken}
   StackRegion=${StackRegion}
+  NPMToken=${NPMToken}
+
+  echo "creating npmrc"
+  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ./.npmrc
 
   echo "parsing received message"
   parse_message
@@ -149,6 +153,9 @@ function main() {
       docker push "$(after_image ${region} ${tag})"
     fi
   done
+
+  echo "removing npmrc"
+  rm -f ./.npmrc
 
   echo "completed successfully"
 }

--- a/ecs-conex.sh
+++ b/ecs-conex.sh
@@ -81,6 +81,10 @@ function credentials() {
   if grep -O "ARG AWS_SESSION_TOKEN" ./Dockerfile > /dev/null 2>&1; then
     [ -n "${sessionToken}" ] && args="--build-arg AWS_ACCESS_KEY_ID=${sessionToken}"
   fi
+
+  if grep -O "ARG NPMToken" ./Dockerfile > /dev/null 2>&1; then
+    [ -n "${NPMToken}" ] && args="--build-arg NPMToken=${NPMToken}"
+  fi
 }
 
 function cleanup() {
@@ -108,9 +112,6 @@ function main() {
   GithubAccessToken=${GithubAccessToken}
   StackRegion=${StackRegion}
   NPMToken=${NPMToken}
-
-  echo "creating npmrc"
-  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ./.npmrc
 
   echo "parsing received message"
   parse_message

--- a/ecs-conex.sh
+++ b/ecs-conex.sh
@@ -154,9 +154,6 @@ function main() {
     fi
   done
 
-  echo "removing npmrc"
-  rm -f ./.npmrc
-
   echo "completed successfully"
 }
 

--- a/ecs-conex.sh
+++ b/ecs-conex.sh
@@ -5,6 +5,7 @@ set -o pipefail
 
 regions=(us-east-1 us-west-2 eu-west-1)
 tmpdir="$(mktemp -d /mnt/data/XXXXXX)"
+echo "sourcing utility functions"
 source utils.sh
 
 function main() {

--- a/test/manual.ecs-conex.sh
+++ b/test/manual.ecs-conex.sh
@@ -8,6 +8,7 @@ set -eu
 # - AWS_ACCESS_KEY_ID
 # - AWS_SECRET_ACCESS_KEY
 # - AWS_SESSION_TOKEN (optional)
+# - TMPDIR
 
 Owner=$1
 Repo=$2
@@ -19,6 +20,7 @@ AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
 AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
 AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
 NPMToken=${NPMToken}
+ApproximateReceiveCount="0"
 
 docker build -t ecs-conex ./
 docker run \
@@ -33,4 +35,5 @@ docker run \
   -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
   -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} \
   -e NPMToken=${NPMToken} \
+  -e ApproximateReceiveCount=${ApproximateReceiveCount} \
   ecs-conex

--- a/test/manual.ecs-conex.sh
+++ b/test/manual.ecs-conex.sh
@@ -18,6 +18,7 @@ GithubAccessToken=${GithubAccessToken}
 AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
 AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
 AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
+NPMToken=${NPMToken}
 
 docker build -qt ecs-conex ./ > /dev/null
 docker run \
@@ -31,4 +32,5 @@ docker run \
   -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
   -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
   -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} \
+  -e NPMToken=${NPMToken} \
   ecs-conex

--- a/test/manual.ecs-conex.sh
+++ b/test/manual.ecs-conex.sh
@@ -20,7 +20,7 @@ AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
 AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
 NPMToken=${NPMToken}
 
-docker build -qt ecs-conex ./ > /dev/null
+docker build -t ecs-conex ./
 docker run \
   -v $TMPDIR:/mnt/data \
   -v /var/run/docker.sock:/var/run/docker.sock \

--- a/test/utils.test.sh
+++ b/test/utils.test.sh
@@ -185,6 +185,7 @@ assert "equal" "${status_url}" "https://api.github.com/repos/test/test/statuses/
 # credentials() setup
 tmpdocker=$(mktemp /tmp/dockerfile-XXXXXX)
 tmpcreds=$(cat ./test/fixtures/creds.test.json)
+MessageId=not_test
 
 function curl () {
   nullRole=$(printenv | grep nullRole | sed 's/.*=//')

--- a/utils.sh
+++ b/utils.sh
@@ -78,6 +78,10 @@ function credentials() {
     args+="--build-arg NPMToken=${npmToken}"
   fi
 
+  if [ ${MessageId} == "test" ]; then
+    return
+  fi
+
   role=$(curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/)
   if [[ -z $role ]]; then
     return


### PR DESCRIPTION
This PR adds an `NPMToken` stack parameter, creates an npmrc file before building, and deletes the npmrc file after the image has successfully finished. The npmrc file is a prerequisite to install private npm modules in the pushing repository.

@rclark, I think this should work if it's run before the [`docker build` step](https://github.com/mapbox/ecs-conex/blob/8b96a95aa2e27f7b92fa6ff5edd4cfd827ddfd56/ecs-conex.sh#L138-L139). Would love your thoughts on this.

cc @willwhite @emilymcafee @yhahn 