### PR TITLE
log prefixing for worker task

### DIFF
--- a/cloudformation/ecs-conex.template.json
+++ b/cloudformation/ecs-conex.template.json
@@ -532,7 +532,25 @@
                             }
                         ],
                         "LogConfiguration": {
-                            "LogDriver": "syslog"
+                            "LogDriver": "syslog",
+                            "Options": {
+                                "tag": {
+                                    "Fn::Join": [
+                                        "-",
+                                        [
+                                            {
+                                                "Ref": "AWS::StackName"
+                                            },
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            {
+                                                "Ref": "GitSha"
+                                            }
+                                        ]
+                                    ]
+                                }
+                            }
                         },
                         "MountPoints": [
                             {


### PR DESCRIPTION
Adds appropriate prefixes to worker logs as well as watcher logs.