### PR TITLE
Don't overwrite existing images

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -119,6 +119,11 @@ function docker_push() {
     ensure_repo ${region}
     login ${region}
 
+    if docker pull "$(after_image ${region})" 2> /dev/null; then
+      echo "found existing image for ${after} in ${region}, skipping push"
+      continue
+    fi
+
     echo "pushing ${after} to ${region}"
     docker tag -f ${repo}:latest "$(after_image ${region})"
     docker push "$(after_image ${region})"


### PR DESCRIPTION
Check for an existing image before pushing on a per-region basis. Refs #42.

This could lead to a scenario where the image in one ECR region is different from one in another (e.g. if a job were to fail after pushing to `us-east-1` but not `us-west-2`, on retry the new build would only go to `us-west-2`). To avoid this we would need some kind of master region (e.g. the last one) that acts as a transactional check -- but this would conflict with moving to parallelized pushes as well.

I'm happy with this approach for now, we can revisit if ^^ actually turns out to be a real thing.

cc @rclark 