### PR TITLE
Flip check in check_dockerfile so we can exit gracefully from caller

### DIFF
--- a/ecs-conex.sh
+++ b/ecs-conex.sh
@@ -36,7 +36,7 @@ function main() {
   cd ${tmpdir} && git checkout -q $after || exit 3
 
   echo "looking for dockerfile"
-  check_dockerfile ./Dockerfile
+  check_dockerfile ./Dockerfile || exit 0
 
   echo "gather local credentials and setup --build-arg"
   credentials ./Dockerfile

--- a/test/utils.test.sh
+++ b/test/utils.test.sh
@@ -160,13 +160,10 @@ assert "equal" "${CALLED}" "1"
 # check_dockerfile() test
 tag_test "check_dockerfile()"
 filepath="/fake/file/path"
-log=$(check_dockerfile ${filepath})
-assert "equal" "${log}" "no Dockerfile found"
-assert "equal" "$?" "0"
+check_dockerfile ${filepath} || assert "equal" "$?" "1"
 
 filepath="ecs-conex.sh"
-log=$(check_dockerfile ${filepath})
-assert "equal" "${log}" ""
+check_dockerfile ${filepath} && assert "equal" "$?" "0"
 
 # check_receives() test
 tag_test "check_receives()"

--- a/utils.sh
+++ b/utils.sh
@@ -51,7 +51,7 @@ function check_dockerfile() {
   filepath=$1
   if [ ! -f ${filepath} ]; then
     echo "no Dockerfile found"
-    exit 0
+    return 1
   fi
 }
 


### PR DESCRIPTION
Took me a second to see this -- calling `exit 0` from within a function doesn't exit the caller so the script continues right past the check right now.

Flips the assertion so we can `exit 0` from one step up.