### PR TITLE
Makes NPMAccessToken optional

### DIFF
--- a/cloudformation/ecs-conex.template.json
+++ b/cloudformation/ecs-conex.template.json
@@ -65,7 +65,8 @@
         },
         "NPMAccessToken": {
             "Type": "String",
-            "Description": "npm access token used to install private packages"
+            "Description": "npm access token used to install private packages",
+            "Default": ""
         }
     },
     "Conditions": {


### PR DESCRIPTION
Refs [PR #26 ](https://github.com/mapbox/ecs-conex/pull/26#issuecomment-235013891)

@rclark, is this all that needs to be done to make this parameter optional? Setting the default to an empty string should cause this to evaluate false and not append the `NPMAccessToken` build argument.