### PR TITLE
Use npm link for watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "test/utils.test.sh"
   },
+  "bin": {
+    "ecs-conex-watch": "scripts/watch.sh"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mapbox/ecs-conex.git"


### PR DESCRIPTION
Allows `npm link` to put `watch.sh` on your $PATH.