### PR TITLE
Silence git clone

### DIFF
--- a/ecs-conex.sh
+++ b/ecs-conex.sh
@@ -32,7 +32,7 @@ function main() {
   github_status "${status}" "ecs-conex is building an image"
   [ "${deleted}" == "true" ] && exit 0
 
-  git clone https://${GithubAccessToken}@github.com/${owner}/${repo} ${tmpdir}
+  git clone -q https://${GithubAccessToken}@github.com/${owner}/${repo} ${tmpdir}
   cd ${tmpdir} && git checkout -q $after || exit 3
 
   echo "looking for dockerfile"


### PR DESCRIPTION
This PR hides`git clone` output.

Currently, repositories that take a while to clone have somewhat spammy logs.

```bash
started task for webhook: {"ref":"refs/heads/master","after":"81f728b7d8ef5c73b85ebef0b077ded481d2c80c","before":"e784e3617a6f48b8d3003d7313a32e79f732d21a","deleted":false,"repository":{"name":"pxm","owner":{"name":"mapbox"}},"pusher":{"name":"jacquestardie"}}
Checking out files:  50% (303/600)
Checking out files:  51% (306/600)
Checking out files:  52% (312/600)
...
Checking out files:  99% (342/600)
...
```

cc @rclark 