### PR TITLE
small change to explicitly output json in `aws describe-stacks ...` cmd

### DIFF
--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -8,7 +8,7 @@ stack=${1:-"us-east-1:ecs-conex-production"}
 region=$(echo $stack | cut -d : -f 1)
 name=$(echo $stack | cut -d : -f 2)
 
-outputs=$(aws cloudformation describe-stacks --region ${region} --stack-name ${name} --query 'Stacks[0].Outputs')
+outputs=$(aws cloudformation describe-stacks --region ${region} --stack-name ${name} --query 'Stacks[0].Outputs' --output json)
 secret=$(node -e "console.log(${outputs}.find(function(o) { return o.OutputKey === 'AccessKeyId'}).OutputValue);")
 url=$(node -e "console.log(${outputs}.find(function(o) { return o.OutputKey === 'WebhookEndpoint'}).OutputValue);")
 


### PR DESCRIPTION
Got this error while trying to run `ecs-conex-watch` on my stack:
```
console.log(The name of the CloudWatch LogGroup where ecs-conex logs are sent      LogGroup           ecs-conex-production-WatchbotLogGroup-1UK1S8HSB9JV8
            ^^^

SyntaxError: missing ) after argument list
    at Object.exports.runInThisContext (vm.js:53:16)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (module.js:434:26)
    at node.js:567:27
    at doNTCallback0 (node.js:408:9)
    at process._tickCallback (node.js:337:13)
```

I hadn't configured `aws-cli` to always output JSON by default, so the output of the [`--describe-stacks`](https://github.com/mapbox/ecs-conex/blob/master/scripts/watch.sh#L11) stumped the watch script. 😅  Initially I thought it was because I had an older version of `aws-cli`, but the problem persisted

[Explicitly adding the `--output json` part to a query](http://docs.aws.amazon.com/cli/latest/userguide/controlling-output.html#controlling-output-format) ensures that the output of an aws-cli command is always JSON.

cc/ @rclark 