### PR TITLE
docker-gitsha.tar.gz image

### DIFF
--- a/cloudformation/ecs-conex.template.js
+++ b/cloudformation/ecs-conex.template.js
@@ -23,22 +23,46 @@ var watcher = watchbot.template({
   alarmThreshold: 20,
   alarmPeriods: 6,
   messageTimeout: 1200,
-  permissions: {
-    Effect: 'Allow',
-    Action: [
-      'ecr:BatchCheckLayerAvailability',
-      'ecr:BatchGetImage',
-      'ecr:CreateRepository',
-      'ecr:DescribeRepositories',
-      'ecr:GetAuthorizationToken',
-      'ecr:GetDownloadUrlForLayer',
-      'ecr:InitiateLayerUpload',
-      'ecr:CompleteLayerUpload',
-      'ecr:UploadLayerPart',
-      'ecr:PutImage'
-    ],
-    Resource: '*'
-  }
+  permissions: [
+    {
+      Effect: 'Allow',
+      Action: [
+        'ecr:BatchCheckLayerAvailability',
+        'ecr:BatchGetImage',
+        'ecr:CreateRepository',
+        'ecr:DescribeRepositories',
+        'ecr:GetAuthorizationToken',
+        'ecr:GetDownloadUrlForLayer',
+        'ecr:InitiateLayerUpload',
+        'ecr:CompleteLayerUpload',
+        'ecr:UploadLayerPart',
+        'ecr:PutImage'
+      ],
+      Resource: '*'
+    },
+    {
+      Effect: 'Allow',
+      Action: [
+        's3:PutObject',
+        's3:PutObjecAcl'
+      ],
+      Resource: [
+        'arn:aws:s3:::sling-to-cn-north-1/slugs/*',
+        'arn:aws:s3:::mapbox-ap-southeast-1/slugs/*'
+      ]
+    },
+    {
+      Effect: 'Allow',
+      Action: [
+        's3:ListBucket',
+        's3:GetBucketLocation'
+      ],
+      Resource: [
+        'arn:aws:s3:::sling-to-cn-north-1',
+        'arn:aws:s3:::mapbox-ap-southeast-1'
+      ]
+    }
+  ]
 });
 
 // Main ecs-conex template

--- a/ecs-conex.sh
+++ b/ecs-conex.sh
@@ -48,6 +48,26 @@ function main() {
   docker build --no-cache --quiet ${args} --tag ${repo}:${after} ${tmpdir}
   docker_push
 
+  if [ -f ".slugger.json" ]; then
+      china=$(jq -r '.["slug-cn-north-1"]' .slugger.json)
+      if [ $china == null ]; then
+          china="false"
+      fi
+  else
+    china="false"
+  fi
+
+  if [ "$china" == "true" ]; then
+      tag="${repo}:${after}"
+      image="docker-${after}.tar.gz"
+      echo "saving Docker image ${tag}"
+      save_dockerimage "${tag}" "${image}" "${tmpdir}"
+      echo "copying ${tag} image to mapbox-ap-southeast-1"
+      copy_slug "ap-southeast-1" "mapbox-ap-southeast-1" "${tmpdir}/${image}" "slugs/${repo}/${image}"
+      echo "slinging tarball to china"
+      sling_to_china "${repo}" "${tag}" "${image}" "${tmpdir}"
+  fi
+
   echo "completed successfully"
 }
 

--- a/utils.sh
+++ b/utils.sh
@@ -136,6 +136,72 @@ function docker_push() {
   done
 }
 
+function copy_slug() {
+  region=$1
+  bucket=$2
+  file=$3
+  key=$4
+  acl=${5:-private}
+
+  if ! aws s3api head-object --bucket ${bucket} --key ${key} > /dev/null 2>&1; then
+      awsretry s3 cp --acl $acl --region ${region} ${file} s3://${bucket}/${key}
+  fi
+}
+
+function awsretry() {
+  local tries=3
+  while ! aws "$@"; do
+    if [ $tries -eq 0 ]; then
+        return 1
+    else
+      echo "aws $@ failed, retrying ..."
+      tries=$(($tries - 1))
+      sleep 5
+    fi
+  done
+  return 0
+}
+
+function save_dockerimage() {
+  tag=$1
+  image=$2
+  cd "$3"
+  echo "Saving image for ${tag} to targz"
+  docker save "${repo}:${tag}" | gzip > "${image}"
+}
+
+function sling_to_china() {
+  repo=$1
+  tag=$2
+  image=$3
+  cd "$4"
+
+  echo "Building manifest file to sling ${tag}"
+  slingWriteBucket=${slingWriteBucket:-"sling-to-cn-north-1"}
+  slingWriteRegion=${slingWriteRegion:-"us-east-1"}
+  slingWritePrefix=${slingWritePrefix:-"slugs"}
+  slingFile="${image}.json"
+  slingKey="${slingWritePrefix}/${repo}/${slingFile}"
+  slingAcl="private"
+  echo "Copying manifest to s3://${slingWriteBucket}/${slingKey}"
+
+  cat <<EOF > ./${slingFile}
+{
+"type": "slug",
+"path": "${slingWritePrefix}/${repo}/${image}"
+}
+EOF
+
+  export -f copy_slug
+  export -f awsretry
+
+  copy_slug "${slingWriteRegion}" "${slingWriteBucket}" "${slingFile}" "${slingKey}" "${slingAcl}"
+  if [ -z "$(aws s3 ls --region ${slingWriteRegion} s3://${slingWriteBucket}/${slingKey})" ]; then
+      echo "Upload to $slingWriteBucket failed, retrying"
+      awsretry s3 cp --acl "${slingAcl}" --region "${slingWriteRegion}" "${slingFile}" "s3://${slingWriteBucket}/${slingKey}"
+  fi
+}
+
 function cleanup() {
   exit_code=$?
 


### PR DESCRIPTION
Saves an image out to `docker-<gitsha>.tar.gz`, copies it to `mapbox-ap-southeast-1` and pings the s3-sling to get it into CN.

I wanted the docker image files to be distinguished from existing slugs in case we have to spin up an old gitsha on the dockerhost api. 
