### PR TITLE
watchbot > 2.0

### DIFF
--- a/cloudformation/ecs-conex.template.js
+++ b/cloudformation/ecs-conex.template.js
@@ -1,5 +1,5 @@
-var watchbot = require('watchbot');
-var cf = require('cloudfriend');
+var watchbot = require('@mapbox/watchbot');
+var cf = require('@mapbox/cloudfriend');
 
 // Build watchbot resources
 var watcher = watchbot.template({
@@ -20,7 +20,7 @@ var watcher = watchbot.template({
   user: true,
   notificationEmail: cf.ref('AlarmEmail'),
   cluster: cf.ref('Cluster'),
-  logAggregationFunction: cf.ref('LogAggregationFunction'),
+  alarmOnEachFailure: true,
   alarmThreshold: 20,
   alarmPeriods: 6,
   messageTimeout: 1200,
@@ -71,11 +71,6 @@ var conex = {
       Description: 'An email address to subscribe to alarms',
       Type: 'String',
       Default: 'devnull@mapbox.com'
-    },
-    LogAggregationFunction: {
-      Description: 'The ARN of a Lambda function that will receive log events from CloudWatch',
-      Type: 'String',
-      Default: 'none'
     }
   },
   Outputs: {

--- a/cloudformation/ecs-conex.template.js
+++ b/cloudformation/ecs-conex.template.js
@@ -71,6 +71,11 @@ var conex = {
       Description: 'An email address to subscribe to alarms',
       Type: 'String',
       Default: 'devnull@mapbox.com'
+    },
+    LogAggregationFunction: {
+      Description: 'The ARN of a Lambda function that will receive log events from CloudWatch',
+      Type: 'String',
+      Default: 'none'
     }
   },
   Outputs: {

--- a/package.json
+++ b/package.json
@@ -23,15 +23,15 @@
   },
   "homepage": "https://github.com/mapbox/ecs-conex#readme",
   "dependencies": {
+    "@mapbox/cloudfriend": "^1.8.1",
+    "@mapbox/watchbot": "^2.2.4",
     "aws-sdk": "^2.4.13",
-    "cloudfriend": "^1.0.0",
     "d3-queue": "^3.0.2",
     "inquirer": "^1.1.2",
     "minimist": "^1.2.0",
     "moment": "^2.14.1",
     "request": "^2.74.0",
-    "underscore": "^1.8.3",
-    "watchbot": "^1.0.4"
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "eslint": "^3.2.0",

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -1,5 +1,5 @@
 var test = require('tape');
-var cf = require('cloudfriend');
+var cf = require('@mapbox/cloudfriend');
 var path = require('path');
 
 test('template is valid', function(assert) {


### PR DESCRIPTION
- Uses watchbot@2.2.4, but opts into `alarmOnEachFailure` to preserve existing alarm behavior
- Uses `@mapbox` namespaced modules
- Removes logAggregationFunction

todo
  - [x] stage
  - [x] confirm log forwarding is stable
  - [ ] merge/deploy

cc @rclark 