### PR TITLE
Bump ecs-watchbot to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/mapbox/ecs-conex#readme",
   "dependencies": {
     "@mapbox/cloudfriend": "^1.8.1",
-    "@mapbox/watchbot": "^2.2.4",
+    "@mapbox/watchbot": "^2.3.0",
     "aws-sdk": "^2.4.13",
     "d3-queue": "^3.0.2",
     "inquirer": "^1.1.2",


### PR DESCRIPTION
Adds the `PendingTime` metric to ecs-conex. Before merging, we should add an alarm for long times spent in PENDING.

cc/ @emilymcafee @l-r @yhahn @rclark 