### PR TITLE
Add pending metric alarm for conex

### DIFF
--- a/cloudformation/ecs-conex.template.js
+++ b/cloudformation/ecs-conex.template.js
@@ -90,7 +90,7 @@ var conex = {
         ComparisonOperator: 'GreaterThanThreshold',
         Namespace: 'Mapbox/ecs-watchbot',
         MetricName: cf.join(['WatchbotWorkerPending', cf.stackName]),
-        AlarmActions: [ cf.ref('AlarmSNSTopic') ]
+        AlarmActions: [cf.ref('AlarmSNSTopic')]
       }
     }
   },

--- a/cloudformation/ecs-conex.template.js
+++ b/cloudformation/ecs-conex.template.js
@@ -18,7 +18,7 @@ var watcher = watchbot.template({
   mounts: '/mnt/data:/mnt/data,/var/run/docker.sock:/var/run/docker.sock',
   webhook: true,
   user: true,
-  notificationEmail: cf.ref('AlarmEmail'),
+  notificationTopic: cf.ref('AlarmSNSTopic'),
   cluster: cf.ref('Cluster'),
   alarmOnEachFailure: true,
   alarmThreshold: 20,
@@ -79,6 +79,18 @@ var conex = {
     }
   },
   Resources: {
+    AlarmSNSTopic: {
+      Type: 'AWS::SNS::Topic',
+      Description: 'Subscribe to this topic to receive emails when tasks fail or retry',
+      Properties: {
+        Subscription: [
+          {
+            Endpoint: cf.ref('AlarmEmail'),
+            Protocol: 'email'
+          }
+        ]
+      }
+    },
     MaxPendingTime: {
       Type: 'AWS::CloudWatch::Alarm',
       Properties: {

--- a/cloudformation/ecs-conex.template.js
+++ b/cloudformation/ecs-conex.template.js
@@ -78,6 +78,22 @@ var conex = {
       Default: 'none'
     }
   },
+  Resources: {
+    MaxPendingTime: {
+      Type: 'AWS::CloudWatch::Alarm',
+      Properties: {
+        AlarmDescription: 'https://github.com/mapbox/ecs-conex/blob/master/docs/alarms.md#maxpendingtime',
+        Period: 60,
+        EvaluationPeriods: 5,
+        Statistic: 'Maximum',
+        Threshold: 120,
+        ComparisonOperator: 'GreaterThanThreshold',
+        Namespace: 'Mapbox/ecs-watchbot',
+        MetricName: cf.join(['WatchbotWorkerPending', cf.stackName]),
+        AlarmActions: [ cf.ref('AlarmSNSTopic') ]
+      }
+    }
+  },
   Outputs: {
     WorkTopic: {
       Description: 'The ARN of ecs-conex\'s SNS topic. Send messages to this topic to have builds processed',

--- a/docs/alarms.md
+++ b/docs/alarms.md
@@ -6,8 +6,8 @@ Time between tasks getting created and actually starting (i.e. staying in PENDIN
 
 #### Problem
 
-Long pending times could contribute to backup of minutes to hours. When the cluster is under heavy load and there is throttling occuring between the ecs-agent and the Agent Control Service (ACS), there is often be a buildup of tasks hanging in the `PENDING` state for a long time. One way to check if the cluster is in this state is to check the cluster's `PendingTasksPerInstance` metric, looking for high averages or a high maximum. The other thing to check is the `WatchbotWorkerPending` metric for all other watchbot stacks. If either of these is high, you are in the throttling scenario.
+Long pending times could contribute to backup of minutes to hours for building docker images. When the cluster is under heavy load it's possible for the Agent Control Service (ACS) to throttle state change requests from the ecs-agent. This usually causes a buildup of tasks hanging in the `PENDING` state for a long time. One way to check if the cluster is in this state is to check the number of tasks in the `PENDING` state on the cluster. If there are more `PENDING` than 10 tasks per host instance on the cluster, it's very likely the ACS service is throttling your state change requests.
 
 #### Solution
 
-Determining which stack is overscaled requires looking at the `WatchbotConcurrency` on the cluster, and seeing if it's high for any watchbot stacks in that region. Once the high-scale watchbot stack is found, contact the stack's owner and see if they can gracefully scale down so that conex isn't negatively impacted.
+If the ACS service is getting throttled (see above), check through the running tasks and see if there is one service or particular family of tasks that is starting and stopping very rapidly on the cluster. If it's possible, scale down that process to return conex pending time to normal.

--- a/docs/alarms.md
+++ b/docs/alarms.md
@@ -1,0 +1,13 @@
+### MaxPendingTime
+
+#### What
+
+Time between tasks getting created and actually starting (i.e. staying in PENDING state) has gone above 120 seconds.
+
+#### Problem
+
+Long pending times could contribute to backup of minutes to hours. When the cluster is under heavy load and there is throttling occuring between the ecs-agent and the Agent Control Service (ACS), there is often be a buildup of tasks hanging in the `PENDING` state for a long time. One way to check if the cluster is in this state is to check the cluster's `PendingTasksPerInstance` metric, looking for high averages or a high maximum. The other thing to check is the `WatchbotWorkerPending` metric for all other watchbot stacks. If either of these is high, you are in the throttling scenario.
+
+#### Solution
+
+Determining which stack is overscaled requires looking at the `WatchbotConcurrency` on the cluster, and seeing if it's high for any watchbot stacks in that region. Once the high-scale watchbot stack is found, contact the stack's owner and see if they can gracefully scale down so that conex isn't negatively impacted.


### PR DESCRIPTION
Adds an alarm on the pending time for ecs-conex. I chose 2 minutes since there's only one point over the last 24 hours of the metric that goes above it - but I'm willing to raise it.

cc/ @rclark @emilymcafee @xrwang 