### PR TITLE
easy access to private npm module doc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ ECS Container Express is a continuous integration service for building [Docker](
 
 ### Dockerfile
 
-The [Dockerfile](https://docs.docker.com/engine/reference/builder/) contains the commands required to build an image, or snapshot of your repository, when you push to GitHub. This file is located in the root directory of your application code.
+The [Dockerfile](https://docs.docker.com/engine/reference/builder/) contains the commands required to build an image, or snapshot of your repository, when you push to GitHub. This file is located in the root directory of your application code. If you are using private npm modules, your Dockerfile might require some additional commands as listed over [here](https://github.com/mapbox/ecs-conex/blob/master/docs/npm.md)
 
 ### ECR Repository
 


### PR DESCRIPTION
Hi, While working on this https://github.com/mapbox/ecs-or-bust/issues/3, I faced an issue where ecs-conex wasn't able to build my commit as I added private npm modules. But that didn't come as an insight to me , because in that commit I didn't change any thing in dockerfile but in package.json and couldn't figure out the reason of failing build. But from ecs-conex logs looked like some authentication issue and  realized the problem. Therefore this might be helpful for anyone else referring to readme file. 

cc @emilymdubois 