### PR TITLE
Add ability to set a repository permission policy

### DIFF
--- a/cloudformation/ecs-conex.template.js
+++ b/cloudformation/ecs-conex.template.js
@@ -13,7 +13,8 @@ var watcher = watchbot.template({
     StackRegion: cf.region,
     AccountId: cf.accountId,
     GithubAccessToken: cf.ref('GithubAccessToken'),
-    NPMAccessToken: cf.ref('NPMAccessToken')
+    NPMAccessToken: cf.ref('NPMAccessToken'),
+    RepositoryPermissionPolicy: cf.ref('RepositoryPermissionPolicy')
   },
   mounts: '/mnt/data:/mnt/data,/var/run/docker.sock:/var/run/docker.sock',
   webhook: true,
@@ -56,6 +57,11 @@ var conex = {
     NPMAccessToken: {
       Type: 'String',
       Description: '[secure] npm access token used to install private packages',
+      Default: ''
+    },
+    RepositoryPermissionPolicy: {
+      Type: 'String',
+      Description: 'An IAM policy granting access for other AWS accounts to access this repository',
       Default: ''
     },
     NumberOfWorkers: {

--- a/cloudformation/ecs-conex.template.js
+++ b/cloudformation/ecs-conex.template.js
@@ -37,7 +37,8 @@ var watcher = watchbot.template({
       'ecr:InitiateLayerUpload',
       'ecr:CompleteLayerUpload',
       'ecr:UploadLayerPart',
-      'ecr:PutImage'
+      'ecr:PutImage',
+      'ecr:SetRepositoryPolicy'
     ],
     Resource: '*'
   }

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,9 @@ ecs-conex will create one ECR repository for each Github repository, and each ti
 
 You only need to run ecs-conex's `watch.sh` script once to subscribe your repository to the ecs-conex webhook. For more information about associating these resources, see the [Getting started](./docs/getting-started.md) documentation.
 
+## Testing
+You must have a `GithubAccessToken` environment varaible set to run the tests. It does not need to be a valid token, it just has to be set. You could do so inline like `GithubAccessToken="test" npm test`
+
 ## Documentation
 
 - [Getting started](./docs/getting-started.md)

--- a/test/utils.test.sh
+++ b/test/utils.test.sh
@@ -131,6 +131,40 @@ create_repo ${test_region}
 assert "equal" "${FAILURE_MESSAGE}" "" "should not have any failures"
 assert "equal" "${CALLED}" "1"
 
+# set_policy() test
+tag_test "set_policy()"
+repo=repo
+test_region=us-east-1
+RepositoryPermissionPolicy="test policy"
+FAILURE_MESSAGE=""
+OUTPUT_POLICY=""
+
+function aws() {
+  if [ "${1}" != "ecr" ]; then
+    FAILURE_MESSAGE="First argument must be ecr"
+  elif [ "$2" != "set-repository-policy" ]; then
+    FAILURE_MESSAGE="Second argument must be set-repository-policy"
+  elif [ "$4" != "${test_region}" ]; then
+    FAILURE_MESSAGE="Fourth argument must be region"
+  elif [ "$6" != "repo" ]; then
+    FAILURE_MESSAGE="Sixth argument must be repo"
+  else
+    OUTPUT_POLICY=$RepositoryPermissionPolicy
+  fi
+}
+
+# test with policy
+export RepositoryPermissionPolicy=$RepositoryPermissionPolicy
+set_policy ${test_region}
+assert "equal" "${FAILURE_MESSAGE}" "" "should not have any failures"
+assert "equal" "${OUTPUT_POLICY}" "${RepositoryPermissionPolicy}"
+
+# test without policy
+unset RepositoryPermissionPolicy
+log=$(set_policy ${test_region})
+assert "equal" "${FAILURE_MESSAGE}" "" "should not have any failures"
+assert equal "${log}" "" "output empty"
+
 # image_exists() test
 tag_test "image_exists()"
 

--- a/utils.sh
+++ b/utils.sh
@@ -28,6 +28,17 @@ function create_repo() {
     --repository-name ${repo} > /dev/null
 }
 
+function set_policy() {
+  local region=$1
+  if [ -n "$RepositoryPermissionPolicy" ]
+  then
+    aws ecr set-repository-policy \
+      --region ${region} \
+      --repository-name ${repo} \
+      --policy-text ${RepositoryPermissionPolicy}
+  fi
+}
+
 function image_exists() {
   local region=$1
   local imgtag=${2:-${after}}
@@ -137,6 +148,7 @@ function docker_push() {
 
   for region in "${regions[@]}"; do
     ensure_repo ${region}
+    set_policy ${region}
 
     # tag + add current image to queue by exact tag match (omitted if no exact match)
     queue="${queue} $(exact_match)"

--- a/utils.sh
+++ b/utils.sh
@@ -30,6 +30,7 @@ function create_repo() {
 
 function set_policy() {
   local region=$1
+  RepositoryPermissionPolicy=$(printenv | grep RepositoryPermissionPolicy | sed 's/.*=//')
   if [ -n "$RepositoryPermissionPolicy" ]
   then
     aws ecr set-repository-policy \
@@ -121,8 +122,6 @@ function credentials() {
   if [[ -n $sessionToken ]] && [[ $sessionToken != "undefined" ]] && grep "ARG AWS_SESSION_TOKEN" ${filepath} > /dev/null 2>&1; then
     args+=" --build-arg AWS_SESSION_TOKEN=${sessionToken}"
   fi
-
-  RepositoryPermissionPolicy=$(printenv | grep RepositoryPermissionPolicy | sed 's/.*=//')
 }
 
 function exact_match() {

--- a/utils.sh
+++ b/utils.sh
@@ -121,6 +121,8 @@ function credentials() {
   if [[ -n $sessionToken ]] && [[ $sessionToken != "undefined" ]] && grep "ARG AWS_SESSION_TOKEN" ${filepath} > /dev/null 2>&1; then
     args+=" --build-arg AWS_SESSION_TOKEN=${sessionToken}"
   fi
+
+  RepositoryPermissionPolicy=$(printenv | grep RepositoryPermissionPolicy | sed 's/.*=//')
 }
 
 function exact_match() {


### PR DESCRIPTION
This change enables ecs-conex to set a Permissions Policy on _all_ repositories watched by this instance of conex. ECR Permissions policies enable you to share an ECR repository in one account with another AWS account. 

*[➡️ Documentation on ECR Repository Policies](http://docs.aws.amazon.com/AmazonECR/latest/userguide/RepositoryPolicies.html)*

**How this feature was implemented**
I've implemented this feature where including an IAM policy document as the `RepositoryPermissionPolicy` stack parameter will set it as an environment variable on the watchbot worker. When a worker is processing a job, after ensuring the ECR repo exists in a given region, the policy for the repository will be set as well (this is an idempotent operation if the policy does not change).

**Testing**
I added what I think are appropriate unit tests to the `test/utils.test.sh` file. I also tested creating an ECR repository using this stack both when the `RepositoryPermissionPolicy` parameter was blank and when it was set to a valid policy to share with another account. In both cases, the expected result happened (the repository was published on ECR, in the former case with no permissions set, in the latter with the specified policy set).