### PR TITLE
Docker version as a stack parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ RUN npm install -g watchbot@^1.0.3 decrypt-kms-env@^2.0.1
 RUN mkdir -p /usr/local/src/ecs-conex
 WORKDIR /usr/local/src/ecs-conex
 
-# Install docker binary matching EC2 version
-RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.12.6.tgz > docker-1.12.6.tgz
+# Install docker binary matching version specified by --build-arg
+ARG DOCKER_VERSION
+RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz > docker-${DOCKER_VERSION}.tgz
 RUN tar -xzf docker-1.12.6.tgz && cp docker/docker /usr/local/bin/docker && chmod 755 /usr/local/bin/docker
 
 # Copy files into the container

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /usr/local/src/ecs-conex
 # Install docker binary matching version specified by --build-arg
 ARG DOCKER_VERSION
 RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz > docker-${DOCKER_VERSION}.tgz
-RUN tar -xzf docker-1.12.6.tgz && cp docker/docker /usr/local/bin/docker && chmod 755 /usr/local/bin/docker
+RUN tar -xzf docker-${DOCKER_VERSION}.tgz && cp docker/docker /usr/local/bin/docker && chmod 755 /usr/local/bin/docker
 
 # Copy files into the container
 COPY ./*.sh ./

--- a/cloudformation/ecs-conex.template.js
+++ b/cloudformation/ecs-conex.template.js
@@ -65,7 +65,7 @@ var conex = {
       Default: 4
     },
     DockerVersion: {
-      Type: 'Number',
+      Type: 'String',
       Description: 'The version of Docker that will run on ecs-conex\'s host EC2s',
       Default: '17.03.1-ce'
     },

--- a/cloudformation/ecs-conex.template.js
+++ b/cloudformation/ecs-conex.template.js
@@ -13,7 +13,8 @@ var watcher = watchbot.template({
     StackRegion: cf.region,
     AccountId: cf.accountId,
     GithubAccessToken: cf.ref('GithubAccessToken'),
-    NPMAccessToken: cf.ref('NPMAccessToken')
+    NPMAccessToken: cf.ref('NPMAccessToken'),
+    DOCKER_VERSION: cf.ref('DockerVersion')
   },
   mounts: '/mnt/data:/mnt/data,/var/run/docker.sock:/var/run/docker.sock',
   webhook: true,
@@ -62,6 +63,11 @@ var conex = {
       Type: 'Number',
       Description: 'The number of concurrent build jobs ecs-conex will perform',
       Default: 4
+    },
+    DockerVersion: {
+      Type: 'Number',
+      Description: 'The version of Docker that will run on ecs-conex\'s host EC2s',
+      Default: '17.03.1-ce'
     },
     Cluster: {
       Description: 'The ARN of the ECS cluster to run on',

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/mapbox/ecs-conex#readme",
   "dependencies": {
     "@mapbox/cloudfriend": "^1.8.1",
-    "@mapbox/watchbot": "^2.4.0",
+    "@mapbox/watchbot": "^2.5.1",
     "aws-sdk": "^2.4.13",
     "d3-queue": "^3.0.2",
     "inquirer": "^1.1.2",

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,8 +2,11 @@
 
 set -eux
 
+docker_version=${1:-17.03.1-ce}
+
 # Log docker client into ECR
-eval "$(aws ecr get-login --region us-east-1)"
+eval "$(aws ecr get-login --region us-east-1 --no-include-email)" || \
+  eval "$(aws ecr get-login --region us-east-1)"
 
 # Make sure the ECR repository exists
 aws ecr describe-repositories --region us-east-1 --repository-names ecs-conex > /dev/null 2>&1 || \
@@ -14,7 +17,7 @@ desc=$(aws ecr describe-repositories --region us-east-1 --repository-names ecs-c
 uri=$(node -e "console.log(${desc}.repositories[0].repositoryUri);")
 
 # Build the docker image
-docker build -t ecs-conex ./
+docker build -t ecs-conex --build-arg DOCKER_VERSION=${docker_version} ./
 
 # Tag the image into the ECR repository
 docker tag ecs-conex "${uri}:$(git rev-parse head)"

--- a/utils.sh
+++ b/utils.sh
@@ -112,8 +112,8 @@ function credentials() {
     args+=" --build-arg AWS_SESSION_TOKEN=${sessionToken}"
   fi
 
-  DockerVersion=${DOCKER_VERSION}
-  if grep "ARG DOCKER_VERSION" ${filepath} > /dev/null 2>&1; then
+  DockerVersion=${DOCKER_VERSION:-}
+  if [[ -n $DockerVersion ]] && grep "ARG DOCKER_VERSION" ${filepath} > /dev/null 2>&1; then
     args+=" --build-arg DOCKER_VERSION=${DockerVersion}"
   fi
 }

--- a/utils.sh
+++ b/utils.sh
@@ -110,6 +110,11 @@ function credentials() {
   if [[ -n $sessionToken ]] && [[ $sessionToken != "undefined" ]] && grep "ARG AWS_SESSION_TOKEN" ${filepath} > /dev/null 2>&1; then
     args+=" --build-arg AWS_SESSION_TOKEN=${sessionToken}"
   fi
+
+  DockerVersion=${DOCKER_VERSION}
+  if grep "ARG DOCKER_VERSION" ${filepath} > /dev/null 2>&1; then
+    args+=" --build-arg DOCKER_VERSION=${DockerVersion}"
+  fi
 }
 
 function exact_match() {

--- a/utils.sh
+++ b/utils.sh
@@ -11,7 +11,8 @@ function after_image() {
 
 function login() {
   local region=$1
-  eval "$(aws ecr get-login --region ${region})"
+  eval "$(aws ecr get-login --region ${region} --no-include-email)" || \
+    eval "$(aws ecr get-login --region ${region})"
 }
 
 function ensure_repo() {


### PR DESCRIPTION
What this PR does:

- Adds a stack parameter `DockerVersion`. This needs to be set to the version of docker that runs on the EC2s that will host ecs-conex.
- If `ARG DOCKER_VERSION` is present in a docker file, then passes the stack parameter value into the image build.
- Adjust's ecs-conex's own Dockerfile to use `ARG DOCKER_VERSION`

@yhahn curious if you think this is a worthwhile approach to dealing with #90? I'm on the fence --- we'll probably just keep changing the default value for the parameter every time there's a docker upgrade in the ecs-optimized AMI anyway. Is making this a configuration option really making anything better?

cc @vsmart 