### PR TITLE
Include multiple versions of docker, extract at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ RUN npm install -g watchbot@^1.0.3 decrypt-kms-env@^2.0.1
 RUN mkdir -p /usr/local/src/ecs-conex
 WORKDIR /usr/local/src/ecs-conex
 
-# Install docker binary matching EC2 version
+# Download several versions of docker
 RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.12.6.tgz > docker-1.12.6.tgz
-RUN tar -xzf docker-1.12.6.tgz && cp docker/docker /usr/local/bin/docker && chmod 755 /usr/local/bin/docker
+RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-17.03.1-ce.tgz > docker-17.03.1-ce.tgz
 
 # Copy files into the container
 COPY ./*.sh ./
@@ -27,4 +27,9 @@ VOLUME /var/run/docker.sock
 VOLUME /mnt/data
 
 # Run the worker
-CMD eval $(decrypt-kms-env) && ./ecs-conex.sh
+CMD eval $(decrypt-kms-env) \
+  && docker_version=$(curl -s --unix-socket /var/run/docker.sock http://localhost/info | jq -r .ServerVersion) \
+  && tar -xzf docker-${docker_version}.tgz \
+  && cp docker/docker /usr/local/bin/docker \
+  && chmod 755 /usr/local/bin/docker \
+  && ./ecs-conex.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu
 
 # Installations
-RUN apt-get update -qq && apt-get install -y curl git python-pip parallel
+RUN apt-get update -qq && apt-get install -y curl git python-pip parallel jq
 RUN pip install awscli
 RUN curl -s https://s3.amazonaws.com/mapbox/apps/install-node/v2.0.0/run | NV=4.4.2 NP=linux-x64 OD=/usr/local sh
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/mapbox/ecs-conex#readme",
   "dependencies": {
     "@mapbox/cloudfriend": "^1.8.1",
-    "@mapbox/watchbot": "^2.4.0",
+    "@mapbox/watchbot": "^2.5.1",
     "aws-sdk": "^2.4.13",
     "d3-queue": "^3.0.2",
     "inquirer": "^1.1.2",

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,6 +3,7 @@
 set -eux
 
 # Log docker client into ECR
+eval "$(aws ecr get-login --region us-east-1 --no-include-email)" || \
 eval "$(aws ecr get-login --region us-east-1)"
 
 # Make sure the ECR repository exists

--- a/utils.sh
+++ b/utils.sh
@@ -11,6 +11,7 @@ function after_image() {
 
 function login() {
   local region=$1
+  eval "$(aws ecr get-login --region ${region} --no-include-email)" || \
   eval "$(aws ecr get-login --region ${region})"
 }
 


### PR DESCRIPTION
An alternative to #102, this approach would include tarballs for multiple docker versions in conex's docker image, select and extract the correct one at runtime.

cc @vsmart @yhahn 
refs #90 