### PR TITLE
Include docker 17.06.2-ce

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /usr/local/src/ecs-conex
 RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.12.6.tgz > docker-1.12.6.tgz
 RUN curl -sL https://download.docker.com/linux/static/stable/x86_64/docker-17.03.1-ce.tgz > docker-17.03.1-ce.tgz
 RUN curl -sL https://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz > docker-17.03.2-ce.tgz
+RUN curl -sL https://download.docker.com/linux/static/stable/x86_64/docker-17.06.2-ce.tgz > docker-17.06.2-ce.tgz
 
 # Copy files into the container
 COPY ./*.sh ./


### PR DESCRIPTION
This supports the newest ecs-optimized AMI.

cc @jakepruitt 