### PR TITLE
Add docker-17.09.1-ce.tgz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.12.6.tgz > dock
 RUN curl -sL https://download.docker.com/linux/static/stable/x86_64/docker-17.03.1-ce.tgz > docker-17.03.1-ce.tgz
 RUN curl -sL https://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz > docker-17.03.2-ce.tgz
 RUN curl -sL https://download.docker.com/linux/static/stable/x86_64/docker-17.06.2-ce.tgz > docker-17.06.2-ce.tgz
+RUN curl -sL https://download.docker.com/linux/static/stable/x86_64/docker-17.09.1-ce.tgz > docker-17.09.1-ce.tgz
 
 # Copy files into the container
 COPY ./*.sh ./


### PR DESCRIPTION
Adds docker-17.09.1-ce.tgz to list of supported docker versions.

Sorry everyone.

cc/ @allierowan @rclark 