### PR TITLE
Tag latest image for repo

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -22,3 +22,9 @@ docker tag ecs-conex "${uri}:$(git rev-parse head)"
 
 # Push the image into the ECR repository
 docker push "${uri}:$(git rev-parse head)"
+
+# if we're on latest master commit, push that as "latest" tag
+if [[ "$(git rev-parse head)" -eq "$(git rev-parse master)" ]] ; then
+  docker tag ecs-conex "${uri}:latest"
+  docker push "${uri}:latest"
+fi


### PR DESCRIPTION
Currently, ecs-conex only tags each image with the git sha, which means you have to specify a tag to pull the image. With this PR, it will update the `latest` tag if the current build is the latest commit to `master`

```shell
# previously
$ docker pull 1234567890.dkr.ecr.eu-west-1.amazonaws.com/my-docker-image:c16abde92e9106b5c47118f20ecc69e51bcbedb6

# with this PR
$ docker pull 1234567890.dkr.ecr.eu-west-1.amazonaws.com/my-docker-image
```

I'm having some trouble getting tests to run locally, so couldn't quite figure out how to write a good test for this. Any advice / suggestions appreciated!