### PR TITLE
Bootstrap should parse git HEAD

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -18,7 +18,7 @@ uri=$(node -e "console.log(${desc}.repositories[0].repositoryUri);")
 docker build -t ecs-conex ./
 
 # Tag the image into the ECR repository
-docker tag ecs-conex "${uri}:$(git rev-parse head)"
+docker tag ecs-conex "${uri}:$(git rev-parse HEAD)"
 
 # Push the image into the ECR repository
-docker push "${uri}:$(git rev-parse head)"
+docker push "${uri}:$(git rev-parse HEAD)"


### PR DESCRIPTION
On linux git requires `HEAD` to be fully uppercased.

Error:
```
++ git rev-parse head
fatal: ambiguous argument 'head': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```