### PR TITLE
bump watchbot version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,9 @@
       }
     },
     "@mapbox/watchbot": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/watchbot/-/watchbot-4.11.1.tgz",
-      "integrity": "sha512-80suQTFhY/kfHnMeftsovFjzDIkFsWqUWNlh/hQbIHmNCBd1jo361SgPLO5iCCJfFgnv5lFgv4fra+adWn75lA==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/watchbot/-/watchbot-4.11.2.tgz",
+      "integrity": "sha512-bpwpdKeR9H3v0toIX6bc6RxeJ0ty1fDdGO/7hVPzR5gzqkTEsK6BdFuqLfCwKao+1klWDYlOCzP2+jnLWcM/gg==",
       "dev": true,
       "requires": {
         "@mapbox/cloudfriend": "^1.9.1",
@@ -839,18 +839,19 @@
       "dev": true
     },
     "event-stream": {
-      "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
+      "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
+        "duplexer": "^0.1.1",
+        "flatmap-stream": "^0.1.0",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
       }
     },
     "events": {
@@ -933,6 +934,12 @@
         "graceful-fs": "^4.1.2",
         "write": "^0.2.1"
       }
+    },
+    "flatmap-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.0.tgz",
+      "integrity": "sha512-Nlic4ZRYxikqnK5rj3YoxDVKGGtUjcNDUtvQ7XsdGLZmMwdUYnXf10o1zcXtzEZTBgc6GxeRpQxV/Wu3WPIIHA==",
+      "dev": true
     },
     "for-each": {
       "version": "0.3.3",
@@ -1597,9 +1604,9 @@
       "dev": true
     },
     "map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
       "dev": true
     },
     "meow": {
@@ -1964,7 +1971,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -2227,15 +2234,15 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
+      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
       "dev": true
     },
     "split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
         "through": "2"
@@ -2264,12 +2271,13 @@
       }
     },
     "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1"
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
       }
     },
     "stream-combiner2": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "underscore": "^1.8.3"
   },
   "devDependencies": {
-    "@mapbox/watchbot": "^4.11.1",
+    "@mapbox/watchbot": "^4.11.2",
     "eslint": "^5.2.0",
     "pinkie-promise": "^2.0.1",
     "sinon": "^6.1.4",


### PR DESCRIPTION
moving watchbot version past a bug in watchbot 4.11.0 - https://github.com/mapbox/ecs-watchbot/pull/289 Doesn't appear to have impacted ecs-conex; but why not avoid potential future confusion.

cc: @vsmart @k-mahoney 